### PR TITLE
markdown: more meaningful link labels

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -187,9 +187,11 @@ func writeMDTree(w io.Writer, node *Node, lvl, blvl int) error {
 		if node.Priority != nil {
 			title = fmt.Sprintf("[P%d] %s", *node.Priority, title)
 		}
-		if node.URL != "" {
-			title += fmt.Sprintf(" ([link](%s))", node.URL)
+
+		if number, err := node.IssueNumber(); err == nil {
+			title += fmt.Sprintf(" ([#%d](%s))", number, node.URL)
 		}
+
 		write("%s* %s\n", strings.Repeat("\t", blvl-1), title)
 		for _, c := range node.Sub {
 			if err := writeMDTree(w, c, lvl+1, blvl+1); err != nil {

--- a/nodes.go
+++ b/nodes.go
@@ -1,5 +1,11 @@
 package okrs
 
+import (
+	"fmt"
+	"path"
+	"strconv"
+)
+
 func NewTree() *Tree {
 	return &Tree{
 		root:  &Node{},
@@ -79,6 +85,16 @@ type Node struct {
 	Sub      []*Node   `json:"sub,omitempty" yaml:"sub,omitempty"`
 
 	parent string
+}
+
+// IssueNumber it returns the issue number for a node.
+func (n *Node) IssueNumber() (int, error) {
+	if n.URL == "" {
+		return 0, fmt.Errorf("no URL defined for this node")
+	}
+
+	_, id := path.Split(n.URL)
+	return strconv.Atoi(id)
 }
 
 func (n *Node) GetProgress() Progress {


### PR DESCRIPTION
Currently, the markdown representation links to the issues, but the label is `link`, not being very meaningful, especially if is printed.

This PRs changes the label by the issue number.
